### PR TITLE
fix: incorrect upload-artifact destination directory; Add right-click item lookup function on Huiji Wiki

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,4 +36,4 @@ jobs:
         with:
           name: dist
           path: |
-            InventoryTools/bin/Release/InventoryTools      
+            InventoryTools/bin/Release/InventoryToolsCN

--- a/InventoryTools/Services/RightClickService.cs
+++ b/InventoryTools/Services/RightClickService.cs
@@ -247,7 +247,7 @@ public class RightClickService
         ImGui.Separator();
         if (ImGui.Selectable("Open in FFXIV-CN HuijiWiki"))
         {
-            $"https://ff14.huijiwiki.com/wiki/%E7%89%A9%E5%93%81:{HttpUtility.UrlEncode(name)}".OpenBrowser();
+            $"https://ff14.huijiwiki.com/wiki/%E7%89%A9%E5%93%81:{HttpUtility.UrlEncode(item.NameString)}".OpenBrowser();
         }
         if (ImGui.Selectable("Open in Garland Tools"))
         {

--- a/InventoryTools/Services/RightClickService.cs
+++ b/InventoryTools/Services/RightClickService.cs
@@ -247,7 +247,7 @@ public class RightClickService
         ImGui.Separator();
         if (ImGui.Selectable("Open in FFXIV-CN HuijiWiki"))
         {
-            $"https://ff14.huijiwiki.com/wiki/%E7%89%A9%E5%93%81:{item.GarlandToolsId}".OpenBrowser();
+            $"https://ff14.huijiwiki.com/wiki/%E7%89%A9%E5%93%81:{HttpUtility.UrlEncode(name)}".OpenBrowser();
         }
         if (ImGui.Selectable("Open in Garland Tools"))
         {

--- a/InventoryTools/Services/RightClickService.cs
+++ b/InventoryTools/Services/RightClickService.cs
@@ -245,6 +245,10 @@ public class RightClickService
     {
         ImGui.Text(item.NameString);
         ImGui.Separator();
+        if (ImGui.Selectable("Open in FFXIV-CN HuijiWiki"))
+        {
+            $"https://ff14.huijiwiki.com/wiki/%E7%89%A9%E5%93%81:{item.GarlandToolsId}".OpenBrowser();
+        }
         if (ImGui.Selectable("Open in Garland Tools"))
         {
             $"https://www.garlandtools.org/db/#item/{item.GarlandToolsId}".OpenBrowser();


### PR DESCRIPTION
### Changes
This PR primarily addresses the issue of the incorrect upload-artifact destination directory.

1. **`.github/workflows/build.yml`**:
   - Changed the upload-artifact destination directory from `InventoryTools/bin/Release/InventoryTools` to `InventoryTools/bin/Release/InventoryToolsCN`.

2. **`InventoryTools/Services/RightClickService.cs`**:
   - Added a new right-click menu option "Open in FFXIV-CN HuijiWiki".
   - Fixed the URL concatenation issue to ensure that the item name is correctly encoded in the URL.

### Additional Note
感谢作者在适配工作上的努力！尽管作者已使国际服插件基本适配国服，但仍有一些细节与国服不完全兼容，例如市场价格查询的区服选择、右键查询功能以及本地化翻译等。考虑到这些问题的开发难度相对较低，且前期适配开发人员较少，我希望能直接与您讨论这些适配工作的具体细节。期待您的回复！